### PR TITLE
Add option to use MacOS launch settings in templates

### DIFF
--- a/VSModTemplates/templates/VintageStoryMod/.template.config/template.json
+++ b/VSModTemplates/templates/VintageStoryMod/.template.config/template.json
@@ -21,6 +21,12 @@
             "description": "Suppresses the external console window on Windows (You may only use this on Windows OS)",
             "defaultValue": "false"
         },
+        "MacOSLaunchSettings": {
+            "type": "parameter",
+            "datatype": "bool",
+            "description": "Launch settings for Mac OS (You may only use this on Mac OS)",
+            "defaultValue": "false"
+        },
         "vsInstall": {
             "type": "parameter",
             "datatype": "string",

--- a/VSModTemplates/templates/VintageStoryMod/_ProjectName_/Properties/launchSettings.json
+++ b/VSModTemplates/templates/VintageStoryMod/_ProjectName_/Properties/launchSettings.json
@@ -5,6 +5,9 @@
       //#if (SuppressWindowsConsoleWindow)
       "executablePath": "$(VINTAGE_STORY)/Vintagestory.exe",
       "commandLineArgs": "--tracelog --addModPath \"$(ProjectDir)/bin/$(Configuration)/Mods\"",
+      //#elseif (MacOSLaunchSettings)
+      "executablePath": "$(VINTAGE_STORY)/Vintagestory",
+      "commandLineArgs": "--tracelog --addModPath \"$(ProjectDir)/bin/$(Configuration)/Mods\"",
       //#else
       "executablePath": "dotnet",
       "commandLineArgs": "\"$(VINTAGE_STORY)/Vintagestory.dll\" --tracelog --addModPath \"$(ProjectDir)/bin/$(Configuration)/Mods\"",
@@ -15,6 +18,9 @@
       "commandName": "Executable",
       //#if (SuppressWindowsConsoleWindow)
       "executablePath": "$(VINTAGE_STORY)/VintagestoryServer.exe",
+      "commandLineArgs": "--tracelog --addModPath \"$(ProjectDir)/bin/$(Configuration)/Mods\"",
+      //#elseif (MacOSLaunchSettings)
+      "executablePath": "$(VINTAGE_STORY)/VintagestoryServer",
       "commandLineArgs": "--tracelog --addModPath \"$(ProjectDir)/bin/$(Configuration)/Mods\"",
       //#else
       "executablePath": "dotnet",

--- a/VSModTemplates/templates/VintageStoryModDLL/.template.config/template.json
+++ b/VSModTemplates/templates/VintageStoryModDLL/.template.config/template.json
@@ -21,6 +21,12 @@
             "description": "Suppresses the external console window on Windows (You may only use this on Windows OS)",
             "defaultValue": "false"
         },
+        "MacOSLaunchSettings": {
+            "type": "parameter",
+            "datatype": "bool",
+            "description": "Launch settings for Mac OS (You may only use this on Mac OS)",
+            "defaultValue": "false"
+        },
         "vsInstall": {
             "type": "parameter",
             "datatype": "string",

--- a/VSModTemplates/templates/VintageStoryModDLL/Properties/launchSettings.json
+++ b/VSModTemplates/templates/VintageStoryModDLL/Properties/launchSettings.json
@@ -5,6 +5,9 @@
       //#if (SuppressWindowsConsoleWindow)
       "executablePath": "$(VINTAGE_STORY)/Vintagestory.exe",
       "commandLineArgs": "--tracelog --addModPath \"$(ProjectDir)/bin/$(Configuration)/Mods\"",
+      //#elseif (MacOSLaunchSettings)
+      "executablePath": "$(VINTAGE_STORY)/Vintagestory",
+      "commandLineArgs": "--tracelog --addModPath \"$(ProjectDir)/bin/$(Configuration)/Mods\"",
       //#else
       "executablePath": "dotnet",
       "commandLineArgs": "\"$(VINTAGE_STORY)/Vintagestory.dll\" --tracelog --addModPath \"$(ProjectDir)/bin/$(Configuration)/Mods\"",
@@ -15,6 +18,9 @@
       "commandName": "Executable",
       //#if (SuppressWindowsConsoleWindow)
       "executablePath": "$(VINTAGE_STORY)/VintagestoryServer.exe",
+      "commandLineArgs": "--tracelog --addModPath \"$(ProjectDir)/bin/$(Configuration)/Mods\"",
+      //#elseif (MacOSLaunchSettings)
+      "executablePath": "$(VINTAGE_STORY)/VintagestoryServer",
       "commandLineArgs": "--tracelog --addModPath \"$(ProjectDir)/bin/$(Configuration)/Mods\"",
       //#else
       "executablePath": "dotnet",


### PR DESCRIPTION
We are few, but there are some, modders on Mac OS. Since I found out the ideal launch settings for Mac OS, something I struggled with a lot when I had just started, it would be nice to make these available for everyone by default.